### PR TITLE
Mateus

### DIFF
--- a/src/static/main.js
+++ b/src/static/main.js
@@ -447,6 +447,7 @@ function hierarchicalBarChart2(parent, data) {
       featureSelection(featureSelected, className);
       positionsChildren = topChildren[d];
       positionsParent = topChildren[d].data.name;
+      console.log(parent)
       hierarchicalBarChart3(positionsParent, positionsChildren);
       if (topChildren[d].data.name.slice(-4) != "bias") {
         nucleotideFeatureView(parent, parent.feature_activations, topChildren[d].data.name);
@@ -907,15 +908,20 @@ function nucleotideFeatureView(parent, data, feature_name) {
   d3.select("svg.nucleotide-zoom").selectAll("*").remove();
 
   var class_name = feature_name.split("_")[0];
+  console.log(class_name) 
+  console.log("data",data)
+  var flat_data =[]
   if (class_name == "incl") {
-    data = flatten_nested_json(data.children[0]).filter(function (d, i, arr) {
+    flat_data = flatten_nested_json(data.children[0]).filter(function (d, i, arr) {
       return d.name.split(" ")[1] == feature_name;
     });
   } else {
-    data = flatten_nested_json(data.children[1]).filter(function (d, i, arr) {
+    flat_data = flatten_nested_json(data.children[1]).filter(function (d, i, arr) {
       return d.name.split(" ")[1] == feature_name;
     });
   }
+  console.log("data post",flat_data)
+
   /* Change y range to a fix range */
   // var max_strength = d3.max(d3.map(data, function (d) { return d.strength / d.length; }).keys());
   var max_strength = 6;
@@ -943,7 +949,7 @@ function nucleotideFeatureView(parent, data, feature_name) {
     gyIncl.transition().duration(800).call(d3.axisLeft(yIncl).ticks(3));
     svg.selectAll("nucleotide-incl-bar")
       // Filter out nucleotide feature with strength < 0.01
-      .data(data.filter(function (d) { return (d.strength / d.length) > 0.01 }))
+      .data(flat_data.filter(function (d) { return (d.strength / d.length) > 0.01 }))
       .enter()
       .append("rect")
       .datum(function (d) { return d; })
@@ -990,7 +996,7 @@ function nucleotideFeatureView(parent, data, feature_name) {
 
     svg.selectAll("nucleotide-skip-bar")
       // Filter out nucleotide feature with strength < 0.01
-      .data(data.filter(function (d) { return (d.strength / d.length) > 0.01 }))
+      .data(flat_data.filter(function (d) { return (d.strength / d.length) > 0.01 }))
       .enter()
       .append("rect")
       .datum(function (d) { return d; })

--- a/src/static/main.js
+++ b/src/static/main.js
@@ -170,7 +170,7 @@ function PSIview(data) {
   }
   // to adjust the width of the bar in the graph we make the 
   // graph rectangle fixed and the make the margins dynamic. 
-  const barWidth = 25;
+  const barWidth = 25*widthRatio;
 
   const bar = chartGroup.append('rect')
     .attr('x', (chartWidth / 2) - (barWidth / 2))
@@ -260,7 +260,7 @@ function hierarchicalBarChart(parent, data) {
     .attr("class", "y-axis")
     .call(yAxis);
 
-  const barWidth = 25;
+  const barWidth = 25*widthRatio;
   let selectedBar = null;
 
   const bars = chart.selectAll(".bar")
@@ -276,6 +276,7 @@ function hierarchicalBarChart(parent, data) {
     .attr("stroke-width", 1);
 
   bars.on("click", function (event, d) {
+    console.log(this)
     if (selectedBar === this) {
       selectedBar = null;
       d3.select(this).attr("fill", d => getFillColor(d));
@@ -298,6 +299,7 @@ function hierarchicalBarChart(parent, data) {
   });
 
   bars.on("mouseover", function (event, d) {
+    console.log(selectedBar)
     if (selectedBar !== this) {
       d3.select(this).transition()
         .duration(100)
@@ -306,6 +308,8 @@ function hierarchicalBarChart(parent, data) {
   });
 
   bars.on("mouseout", function (event, d) {
+    console.log(selectedBar)
+
     if (selectedBar !== this) {
       d3.select(this).transition()
         .duration(100)
@@ -401,8 +405,8 @@ function hierarchicalBarChart2(parent, data) {
     .attr("text-anchor", "middle")
     .attr("dominant-baseline", "middle");
 
-  const barWidth = 25;
-  const barSpacing = 4;
+  const barWidth = 25*widthRatio;
+  const barSpacing = 4*widthRatio;
 
   topChildren.forEach(ele => {
     if (ele.data.name === selected) {
@@ -560,8 +564,8 @@ function hierarchicalBarChart3(parentName, data) {
     .call(yAxis);
 
   let selectedPosition = null;
-  const barWidth = 25;
-  const barSpacing = 2.5;
+  const barWidth = 25* widthRatio;
+  const barSpacing = 2.5* widthRatio;
 
   const bars = chart.selectAll(".bar")
     .data(topChildren)

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -102,7 +102,7 @@ html {
     margin-top: 10px;
     margin-bottom: 0.625rem;
     text-align: center;
-    font-size: 0.875rem;
+    font-size: 14px;
     font-weight: 50;
   }
   

--- a/src/static/utils.js
+++ b/src/static/utils.js
@@ -233,10 +233,16 @@ legend.append('text')
           previous = selected
           selected = d.feature
           previousClass = selectedClass
-          selectedClass = d.feature.split('_')[0]      
-          const childreData = d.feature.split("_")[0] === 'incl' ? Data.feature_activations.children[0] : Data.feature_activations.children[1] 
-    
-          hierarchicalBarChart2(d.feature.split("_")[0],childreData)
+          selectedClass = d.feature.split('_')[0]    
+          const childrenData = d.feature.split("_")[0] === 'incl' ? Data.feature_activations.children[0] : Data.feature_activations.children[1]
+          console.log("data",childrenData)
+
+          if (Data) {
+            hierarchicalBarChart2(Data,childrenData)
+            nucleotideFeatureView(Data, Data.feature_activations, d.feature);
+          }  
+
+          // hierarchicalBarChart2(Data.feature_activations,childrenData)
           if(selectedClass === 'skip'){
             d3.select("svg.feature-view-1")
             .selectAll(`.bar-incl` )
@@ -270,10 +276,6 @@ legend.append('text')
 
           featureSelection(d.feature, d.feature.split("_")[0]);
           // this is causing to reset the feature legend 
-          console.log(Data.feature_activations.children[0])
-          if (Data) {
-            nucleotideFeatureView(Data, Data.feature_activations, d.feature);
-          }
         });
     });
 

--- a/src/static/utils.js
+++ b/src/static/utils.js
@@ -98,9 +98,8 @@ function featureSelection(featureName = null, className = null) {
   const titleDiv = document.querySelector('.feature-legend-title'); // Select the title div
   const widthRatio = width / 491;
   const heightRatio = height / 381;
-  console.log(widthRatio,heightRatio)
   
-  titleDiv.style.fontSize = `${0.875*widthRatio}rem`;
+  // titleDiv.style.fontSize = `${0.875*widthRatio}rem`;
 
   const legendInfo = [{ title: `Skipping`, color: skipping_color,highlight:skipping_highlight_color }, { title: `Inclusion`, color: inclusion_color }];
 
@@ -209,7 +208,6 @@ legend.append('text')
 
           d3.select("svg.feature-view-2")
             .selectAll(".bar." + d.feature)
-            // .transition(300)
             .attr("fill", colors[1]);
        
         background.transition(300).style("fill", colors[0]);
@@ -220,7 +218,6 @@ legend.append('text')
           if(d.feature !== selected){
             d3.select("svg.feature-view-2")
             .selectAll(".bar." + d.feature)
-            // .transition(300)
             .attr("fill", colors[0]);
           }
           
@@ -235,14 +232,11 @@ legend.append('text')
           previousClass = selectedClass
           selectedClass = d.feature.split('_')[0]    
           const childrenData = d.feature.split("_")[0] === 'incl' ? Data.feature_activations.children[0] : Data.feature_activations.children[1]
-          console.log("data",childrenData)
 
           if (Data) {
             hierarchicalBarChart2(Data,childrenData)
             nucleotideFeatureView(Data, Data.feature_activations, d.feature);
           }  
-
-          // hierarchicalBarChart2(Data.feature_activations,childrenData)
           if(selectedClass === 'skip'){
             d3.select("svg.feature-view-1")
             .selectAll(`.bar-incl` )

--- a/src/static/utils.js
+++ b/src/static/utils.js
@@ -98,7 +98,8 @@ function featureSelection(featureName = null, className = null) {
   const titleDiv = document.querySelector('.feature-legend-title'); // Select the title div
   const widthRatio = width / 491;
   const heightRatio = height / 381;
-  
+  titleDiv.style.fontSize = `${14*widthRatio}px`;
+
   const legendInfo = [
     { title: `Skipping`, name: 'skip', color: skipping_color, highlight: skipping_highlight_color }, 
     { title: `Inclusion`, name: 'incl', color: inclusion_color, highlight: inclusion_highlight_color }];
@@ -190,9 +191,6 @@ legend.append('text')
         if (d.feature === featureName) {
           background.style("fill", colors[0])
         }
-        // else if (d.feature.split('_')[1] === featureName.split('_')[1] && featureName.split('_')[1] == 'struct') {
-        //   background.style("fill", colors[0]);
-        // } 
         else {
           background.style("fill", "none");
         }


### PR DESCRIPTION
- removing the transition from main graphs
-  Fix the bug related to a sequence of steps. user clicking on feature legend motif then clicking on feature bar would assign a data value to null and the exon feature view was breaking.
- removed the widthRatio variable from resizing the feature legend title. 
- solved some conflicts I had created by accident. 


### 2nd pr
- adjusted the width of the bars in the upper charts
- returned the width ratio variable to updating the feature legend title.
